### PR TITLE
Implementation of Telegram OAuth Support (GitHub Externship)

### DIFF
--- a/019-telegram-OAuth-support.md
+++ b/019-telegram-OAuth-support.md
@@ -1,0 +1,24 @@
+# Telegram OAuth Support
+
+- Implementation Owner: @Mobasherah12
+- Start Date: 23-12-2021
+- Target Date: N/A
+- Appwrite Issue: https://github.com/appwrite/appwrite/issues/410
+  
+
+## Summary
+
+[summary]: #summary
+
+I am trying to implement the Telegram OAuth support, which allows an individual to add custom unique parameter that would be passed from beginning of authorization to the end, without any need to provide their credentials.
+
+
+## Problem Statement (Step 1)
+
+[problem-statement]: Telegram OAuth support to avoid the need of providing user credentials.
+
+**What problem are you trying to solve?**
+
+Hi, I came across issue #410 that has a list of OAuth providers yet to be implemented in Appwrite. One of those includes the Telegram OAuth support, which will help in creating silent OAuth just similar to how it's done in GitHub.
+
+


### PR DESCRIPTION
Hi, I came across issue [#410](https://github.com/appwrite/appwrite/issues/410) that has a list of OAuth providers yet to be implemented in Appwrite. One of those includes the Telegram OAuth support, which will help in creating silent OAuth just similar to how it's done in GitHub.